### PR TITLE
Refactor various commands for cleaner logging

### DIFF
--- a/commands/admin.py
+++ b/commands/admin.py
@@ -2,25 +2,12 @@
 from logging import getLogger
 
 from telegram import Update
-from telegram.constants import ChatAction
 from telegram.ext import ContextTypes
 
 from utils.decorators import restricted
 from utils.text_handling import cut_command_text
 from telethon import TelegramClient
 from configurations import settings
-
-import re
-import os
-import json
-import requests
-import openai
-import utils
-import telegram
-import sympy
-import numpy as np
-import scipy
-import pandas
 
 
 # Init logger
@@ -35,7 +22,7 @@ async def py(update: Update, context: ContextTypes.DEFAULT_TYPE) -> str:
         a = eval(cmd)
     except Exception as e:
         a = e
-    print(a)
+    logger.debug(a)
     await update.message.reply_text(f"`{a}`", parse_mode="MarkdownV2")
 
 
@@ -46,7 +33,7 @@ async def apy(update: Update, context: ContextTypes.DEFAULT_TYPE) -> str:
         a = await eval(cmd)
     except Exception as e:
         a = e
-    print(a)
+    logger.debug(a)
     await update.message.reply_text(f"`{a}`", parse_mode="MarkdownV2")
 
 
@@ -59,5 +46,6 @@ async def admin(update: Update, context: ContextTypes.DEFAULT_TYPE) -> str:
             a = str(await eval("client." + cmd))
     except Exception as e:
         a = str(e)
-    print(a)
+    logger.debug(a)
     await update.message.reply_text(f"`{a[:4000]}`", parse_mode="MarkdownV2")
+

--- a/commands/ban.py
+++ b/commands/ban.py
@@ -2,28 +2,23 @@
 from logging import getLogger
 
 from telegram import Update
-from telegram.constants import ChatAction
 from telegram.ext import ContextTypes
 
-from utils.decorators import restricted
-from utils.text_handling import cut_command_text
-from telethon import TelegramClient
-from configurations import settings
-import asyncio
+logger = getLogger(__name__)
 
 
 async def delete_msg(update: Update, context: ContextTypes.DEFAULT_TYPE) -> str:
-    # await asyncio.sleep(4)
     await context.bot.delete_message(
-        chat_id=update.message.chat.id, message_id=update.message.message_id
+        chat_id=update.message.chat.id,
+        message_id=update.message.message_id,
     )
 
 
 async def delete_pic(update: Update, context: ContextTypes.DEFAULT_TYPE) -> str:
-    # await asyncio.sleep(4)
-    print("this is pic ", update.message.sticker.file_unique_id)
+    logger.debug("this is pic %s", update.message.sticker.file_unique_id)
     a = "AgADBBAAAmovCVU"
     if update.message.sticker.file_unique_id == a:
         await context.bot.delete_message(
-            chat_id=update.message.chat.id, message_id=update.message.message_id
+            chat_id=update.message.chat.id,
+            message_id=update.message.message_id,
         )

--- a/commands/chat_turbo.py
+++ b/commands/chat_turbo.py
@@ -11,7 +11,6 @@ from constants import ai
 
 from configurations import settings
 
-import openai
 from openai import AsyncOpenAI
 
 aclient = AsyncOpenAI(api_key=settings.OPENAI_API_KEY)

--- a/commands/hs.py
+++ b/commands/hs.py
@@ -24,7 +24,7 @@ async def hs(update: Update, context: ContextTypes.DEFAULT_TYPE) -> str:
     args = args.replace("）", ")")
     args = args.replace("，", ",")
     url = "https://tryhaskell.org/eval?exp="
-    print(url + args)
+    logger.debug(url + args)
     a = requests.get(url + quote(args), timeout=10)
     if a.ok:
         try:

--- a/main.py
+++ b/main.py
@@ -2,6 +2,7 @@ from telegram.ext import Application
 from telegram.ext import CommandHandler
 from telegram.ext import filters
 from telegram.ext import MessageHandler
+import logging
 
 from commands.maintenance import maintenance
 from commands.start import start
@@ -18,6 +19,8 @@ from configurations import settings
 from configurations.settings import IS_MAINTENANCE
 from utils import logger
 
+log = logging.getLogger(__name__)
+
 if __name__ == "__main__":
     logger.init_logger(f"logs/{settings.NAME}.log")
     application = (
@@ -28,7 +31,7 @@ if __name__ == "__main__":
         .get_updates_read_timeout(50)
         .build()
     )
-    print(f"IS_MAINTENANCE = {IS_MAINTENANCE}")
+    log.info("IS_MAINTENANCE = %s", IS_MAINTENANCE)
     if IS_MAINTENANCE:
         application.add_handler(CommandHandler("start", maintenance))
     else:

--- a/utils/decorators.py
+++ b/utils/decorators.py
@@ -1,6 +1,9 @@
 from functools import wraps
+from logging import getLogger
 
 from configurations.settings import LIST_OF_ADMINS
+
+logger = getLogger(__name__)
 
 
 def restricted(func):
@@ -8,7 +11,7 @@ def restricted(func):
     async def wrapped(update, context, *args, **kwargs):
         user_id = update.effective_user.id
         if user_id not in LIST_OF_ADMINS:
-            print(f"Unauthorized access denied for {user_id}.")
+            logger.warning("Unauthorized access denied for %s.", user_id)
             return
         return await func(update, context, *args, **kwargs)
 

--- a/utils/logger.py
+++ b/utils/logger.py
@@ -3,28 +3,25 @@ import logging
 from logging.handlers import TimedRotatingFileHandler
 
 
-def init_logger(logfile: str):
+def init_logger(logfile: str) -> logging.Logger:
     """Initialize the root logger and standard log handlers."""
     log_formatter = logging.Formatter(
         "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
     )
     root_logger = logging.getLogger()
     root_logger.setLevel(logging.DEBUG)
+
     rotate = TimedRotatingFileHandler(
-        "sample.log",
+        logfile,
         when="D",
         interval=1,
         backupCount=0,
-        encoding=None,
-        delay=False,
-        utc=False,
     )
+    rotate.setFormatter(log_formatter)
     root_logger.addHandler(rotate)
-
-    file_handler = logging.FileHandler(logfile)
-    file_handler.setFormatter(log_formatter)
-    root_logger.addHandler(file_handler)
 
     console_handler = logging.StreamHandler()
     console_handler.setFormatter(log_formatter)
     root_logger.addHandler(console_handler)
+
+    return root_logger


### PR DESCRIPTION
## Summary
- drop unused imports and prints from several command modules
- log unauthorized access in decorators
- switch startup print to logger

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `find . -name '*.py' | xargs python -m py_compile`


------
https://chatgpt.com/codex/tasks/task_e_683ef65188c88320bd7c39e9c784e8f2