### PR TITLE
Enable mention and reply triggers for chat

### DIFF
--- a/commands/chat_turbo.py
+++ b/commands/chat_turbo.py
@@ -22,11 +22,13 @@ logger = getLogger(__name__)
 
 
 async def get_turbo_reply(t: str):
-    response = await aclient.chat.completions.create(model="gpt-4.1",
-    messages=[
-        {"role": "system", "content": ai.prompt_shinnku},
-        {"role": "user", "content": t},
-    ])
+    response = await aclient.chat.completions.create(
+        model="gpt-4.1",
+        messages=[
+            {"role": "system", "content": ai.prompt_shinnku},
+            {"role": "user", "content": t},
+        ],
+    )
     content = json.loads(response.choices[0].json())["message"]["content"]
     return replace_ai2shinnku(content)
 
@@ -40,5 +42,41 @@ async def chat_turbo_cmd(update: Update, context: ContextTypes.DEFAULT_TYPE) -> 
 
 @send_action(ChatAction.TYPING)
 async def chat_turbo_ref(update: Update, context: ContextTypes.DEFAULT_TYPE) -> str:
-    content = await get_turbo_reply(update.message.text.strip())
+    message = update.message
+    text = message.text.strip()
+
+    # Check if the current message is a reply to the bot
+    reply_to_bot = (
+        message.reply_to_message
+        and message.reply_to_message.from_user
+        and message.reply_to_message.from_user.id == context.bot.id
+    )
+
+    # Remove direct mentions of the bot and detect if one was present
+    mentioned = False
+    if message.entities:
+        for entity in message.entities:
+            if entity.type in ("mention", "text_mention"):
+                mention_text = message.text[
+                    entity.offset : entity.offset + entity.length
+                ]
+                if (
+                    entity.type == "text_mention"
+                    and entity.user
+                    and entity.user.id == context.bot.id
+                ) or (
+                    entity.type == "mention"
+                    and mention_text.lstrip("@") == context.bot.username
+                ):
+                    text = (
+                        message.text[: entity.offset]
+                        + message.text[entity.offset + entity.length :]
+                    ).strip()
+                    mentioned = True
+                    break
+
+    if not reply_to_bot and not mentioned:
+        return
+
+    content = await get_turbo_reply(text)
     await update.message.reply_text(content)

--- a/main.py
+++ b/main.py
@@ -38,7 +38,8 @@ if __name__ == "__main__":
         application.add_handler(CommandHandler("start", start))
         application.add_handler(
             MessageHandler(
-                filters.TEXT & filters.Regex(r"(啊(这|這)|(hai|海|🌊).*(⭐️|星|xin)|azkhx|quq)"),
+                filters.TEXT
+                & filters.Regex(r"(啊(这|這)|(hai|海|🌊).*(⭐️|星|xin)|azkhx|quq)"),
                 delete_msg,
             )
         )
@@ -48,6 +49,12 @@ if __name__ == "__main__":
         application.add_handler(CommandHandler("music", netease))
         application.add_handler(CommandHandler("okiru", okiru))
         application.add_handler(CommandHandler("chat", chat_turbo_cmd))
+        application.add_handler(
+            MessageHandler(
+                filters.TEXT & (filters.Mention(settings.NAME) | filters.REPLY),
+                chat_turbo_ref,
+            )
+        )
         application.add_handler(CommandHandler("py", py))
         application.add_handler(CommandHandler("rust", rs))
         application.add_handler(CommandHandler("apy", apy))


### PR DESCRIPTION
## Summary
- allow @mention or replying to the bot as triggers for chat
- register new message handler to use the trigger

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d751e307083208d954ac1ffefa32b